### PR TITLE
The test folder has a 37MB fixture in it

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,39 @@
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Editors
+.vscode
+
+# Node Related Folders
+build
+node_modules
+coverage
+.nyc_output
+test


### PR DESCRIPTION
This bloats the package unnecessarily so am suggesting this ignore file to exclude the `test` from being published.